### PR TITLE
Using Rpi clones for CC2510lib flashing

### DIFF
--- a/Python/cclib/ccdebugger.py
+++ b/Python/cclib/ccdebugger.py
@@ -315,9 +315,9 @@ class CCDebugger:
 		# Send chip erase command & update debug status
 		self.debugStatus = self.sendFrame(CMD_CHPERASE)
 
-		# Wait until CHIP_ERASE_BUSY goes down
+		# Wait until CHIP_ERASE_DONE goes up
 		s = self.getStatus()
-		while (( s & 0x80 ) != 0):
+		while (( s & 0x80 ) == 0):
 			time.sleep(0.01)
 			s = self.getStatus()
 
@@ -829,9 +829,9 @@ def renderDebugStatus(cfg):
 	Visualize debug status
 	"""
 	if (cfg & 0x80) != 0:
-		print " [X] CHIP_ERASE_BUSY"
+		print " [X] CHIP_ERASE_DONE"
 	else:
-		print " [ ] CHIP_ERASE_BUSY"
+		print " [ ] CHIP_ERASE_DONE"
 	if (cfg & 0x40) != 0:
 		print " [X] PCON_IDLE"
 	else:


### PR DESCRIPTION
Hello, I already had an Rpi clone lying around (Banana pro) so I tried to use this. Of course the provided CCLib only works for BCM CPUs, so it wouldn't work.
The correct way to use Rpi clones is to download the WiringPi fork ported to Banana Pi/Pro and others running the same AllWinner A20 CPU. Fork called [WiringBP](https://github.com/LeMaker/WiringBP).
Then we'll need the Python bindings/wrapper for that, which is made originally for the BPI clone (same architecture), called [BPI-WiringPi2-Python](https://github.com/BPI-SINOVOIP/BPI-WiringPi2-Python).
Then, we'll need to edit the file CC2510Lib/Python/cclib/ccraspberry.py and change all uses of library "wiringpi" to "wiringpi2".
These steps made my Rpi clone run the python scripts correctly.

However, I now face a strange problem. Whenever I run any of the example programs such as cc_info.py, it hangs indefinately.

EDIT: Sorry, this is my first time using github, I did not mean to create a request to "merge 2 commits".
